### PR TITLE
Update feed screen and post card for new Post model

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -8,21 +8,51 @@ import { FlatList, StyleSheet } from 'react-native';
 const posts: Post[] = [
   {
     id: '1',
+    user_id: 'u1',
+    content: 'Looking for a bassist for my indie rock project in NYC 🎸',
+    caption: '',
+    created_at: '2024-01-01',
+    updated_at: '2024-01-01',
+    visibility: 'public',
+    likes_count: 12,
+    comments_count: 3,
     userName: 'Alex Rivera',
     userProfilePicture: 'https://i.pravatar.cc/100?img=1',
-    image: 'https://images.unsplash.com/photo-1511376777868-611b54f68947',
-    text: 'Looking for a bassist for my indie rock project in NYC 🎸',
+    post_media: [
+      {
+        id: 'm1',
+        url: 'https://images.unsplash.com/photo-1511376777868-611b54f68947',
+        type: 'image',
+      },
+      {
+        id: 'm2',
+        url: 'https://sample-videos.com/video123/mp4/720/big_buck_bunny_720p_1mb.mp4',
+        type: 'video',
+      },
+    ],
     showActions: true,
   },
   {
     id: '2',
+    user_id: 'u2',
+    content: 'Open to collabs for an online jazz jam. DM me! 🎷💬',
+    caption: '',
+    created_at: '2024-01-02',
+    updated_at: '2024-01-02',
+    visibility: 'public',
+    likes_count: 5,
+    comments_count: 1,
     userName: 'JazzQueen',
     userProfilePicture: 'https://i.pravatar.cc/100?img=2',
-    image: '',
-    text: 'Open to collabs for an online jazz jam. DM me! 🎷💬',
+    post_media: [
+      {
+        id: 'm3',
+        url: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3',
+        type: 'audio',
+      },
+    ],
     showActions: true,
   },
-  // Add more dummy posts here
 ];
 
 const FeedScreen = () => {

--- a/components/PostCard/PostCard.tsx
+++ b/components/PostCard/PostCard.tsx
@@ -4,7 +4,8 @@ import { darkThemeColors, lightThemeColors } from '@/constants';
 import { useTheme } from '@/hooks/ThemeContext';
 import Post from '@/models/post';
 import React from 'react';
-import { Image, StyleSheet, Text, View } from 'react-native';
+import { Image, StyleSheet, Text, View, ScrollView } from 'react-native';
+import { Video } from 'expo-av';
 import PostActionIcon from './PostActionIcon';
 
 type Props = {
@@ -19,28 +20,65 @@ const PostCard = ({ post }: Props) => {
   return (
     <View style={getStyles(theme).card}>
       <View style={getStyles(theme).header}>
-        <Image source={{ uri: post.userProfilePicture }} style={getStyles(theme).avatar} />
-        <Text style={getStyles(theme).name}>{post.userName}</Text>
+        {post.userProfilePicture && (
+          <Image
+            source={{ uri: post.userProfilePicture }}
+            style={getStyles(theme).avatar}
+          />
+        )}
+        {post.userName && <Text style={getStyles(theme).name}>{post.userName}</Text>}
       </View>
-      <Text style={getStyles(theme).text}>{post.text}</Text>
-      {post.image ? <Image source={{ uri: post.image }} style={getStyles(theme).postImage} /> : null}
+      <Text style={getStyles(theme).text}>{post.content}</Text>
+      {post.post_media && post.post_media.length > 0 && (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={{ marginTop: 8 }}
+        >
+          {post.post_media.map((media) => (
+            <View key={media.id} style={getStyles(theme).mediaWrapper}>
+              {media.type === 'image' && (
+                <Image source={{ uri: media.url }} style={getStyles(theme).postImage} />
+              )}
+              {(media.type === 'video' || media.type === 'audio') && (
+                <Video
+                  source={{ uri: media.url }}
+                  style={media.type === 'audio' ? getStyles(theme).audio : getStyles(theme).postImage}
+                  useNativeControls
+                  resizeMode="contain"
+                />
+              )}
+            </View>
+          ))}
+        </ScrollView>
+      )}
       {post.showActions && (
         <View style={getStyles(theme).actions}>
-          <PostActionIcon name="musical-notes-outline" 
-            onPress={() => console.log("Liked!")}
-            color={getStyles(theme).text.color} />
-          <PostActionIcon name="chatbubble-outline" 
-            onPress={() => console.log("Commented!") /* This will have to be implemented (AYRTON) */ }
-            color={getStyles(theme).text.color} /> {/* The icon outline color will match the theme! */ }
-          <PostActionIcon name="paper-plane-outline" 
-            onPress={() => console.log("Message the author!")}
-            color={getStyles(theme).text.color} />
-          <PostActionIcon name="share-social-outline" 
-            onPress={() => console.log("Shared!")} 
-            color={getStyles(theme).text.color} />
-          <PostActionIcon name="bookmark-outline" 
-            onPress={() => console.log("Saved!")}
-            color={getStyles(theme).text.color} />
+          <PostActionIcon
+            name="musical-notes-outline"
+            onPress={() => console.log('Liked!')}
+            color={getStyles(theme).text.color}
+          />
+          <PostActionIcon
+            name="chatbubble-outline"
+            onPress={() => console.log('Commented!') /* This will have to be implemented (AYRTON) */}
+            color={getStyles(theme).text.color}
+          />
+          <PostActionIcon
+            name="paper-plane-outline"
+            onPress={() => console.log('Message the author!')}
+            color={getStyles(theme).text.color}
+          />
+          <PostActionIcon
+            name="share-social-outline"
+            onPress={() => console.log('Shared!')}
+            color={getStyles(theme).text.color}
+          />
+          <PostActionIcon
+            name="bookmark-outline"
+            onPress={() => console.log('Saved!')}
+            color={getStyles(theme).text.color}
+          />
         </View>
       )}
     </View>
@@ -85,6 +123,14 @@ const getStyles = (theme: 'light' | 'dark') =>
     width: '100%',
     height: 180,
     borderRadius: 10,
+    marginTop: 8,
+  },
+  mediaWrapper: {
+    marginRight: 8,
+  },
+  audio: {
+    width: 250,
+    height: 50,
     marginTop: 8,
   },
   actions: {

--- a/models/post.ts
+++ b/models/post.ts
@@ -1,21 +1,25 @@
-export default interface Post {
-    id: string;
-    userId?: string; // id dell' utente che ha creato il post
-    type?: 'text' | 'image' | 'video' | 'audio';
-    uri?: string;
-    createdAt?: string;
-    userName?: string; // name e image forse andranno tolti perché si possono prendere dal profilo dell' utente avendo l' id
-    userProfilePicture?: string;
-    image?: string; // URL dell' immagine del post
-    text?: string;
-    showActions?: boolean; // se mostrare le azioni come like, commento, condivisione
-
-    tags?: string[]; // ad esempio "#jazz", "#rock", "#pop"
-    likes?: number; // numero di like
-    comments?: number; // numero di commenti
-    shares?: number; // numero di condivisioni
-    isLiked?: boolean; // se l' utente ha messo like al post
-    isShared?: boolean; // se l' utente ha condiviso il post
-    isCommented?: boolean; // se l' utente ha commentato il post
-    isSaved?: boolean; // se l' utente ha salvato il post
+export interface PostMedia {
+  id: string;
+  url: string;
+  type: 'image' | 'video' | 'audio';
+  position?: number;
 }
+
+export default interface Post {
+  id: string;
+  user_id: string;
+  content: string;
+  caption: string;
+  created_at: string;
+  updated_at: string;
+  visibility: string;
+  likes_count: number;
+  comments_count: number;
+
+  // Optional fields retrieved via joins or for UI convenience
+  userName?: string;
+  userProfilePicture?: string;
+  post_media?: PostMedia[];
+  showActions?: boolean;
+}
+


### PR DESCRIPTION
## Summary
- update Post interface to reflect latest fields
- rewrite feed screen dummy data to match the new model
- extend PostCard to render multiple media items including video and audio

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688417c26ae48326b5bf0796adc5b97b